### PR TITLE
fix: footer links wrapped

### DIFF
--- a/src/app/components/Generic/Footer.js
+++ b/src/app/components/Generic/Footer.js
@@ -15,7 +15,7 @@ const Footer = () => {
         </Col>
         <Col>
           <Row>
-            <Col xs={4}>
+            <Col xs={3}>
               <Link to='/terms'>
                 <div className='text-muted fw-bold'>Terms of Service</div>
               </Link>
@@ -25,12 +25,12 @@ const Footer = () => {
                 <div className='text-muted fw-bold'>Privacy Policy</div>
               </Link>
             </Col>
-            <Col xs={2}>
+            <Col xs={3}>
               <Link to='/faq'>
                 <div className='text-muted fw-bold'>FAQ</div>
               </Link>
             </Col>
-            <Col xs={2}>
+            <Col xs={3}>
               <Link to='/support'>
                 <div className='text-muted fw-bold'>Support</div>
               </Link>


### PR DESCRIPTION
Prev:
<img width="530" alt="CleanShot 2022-07-26 at 15 35 35@2x" src="https://user-images.githubusercontent.com/104367442/181096876-e8e342a6-6929-4227-ae5e-266a9837537a.png">

Now:
![image](https://user-images.githubusercontent.com/104367442/181096911-22a3bb6c-208b-448c-8fd8-3f7da905ed92.png)
