### PR TITLE
[VLT-320] fix: API call 401

### DIFF
--- a/src/app/contexts/auth.js
+++ b/src/app/contexts/auth.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
 import * as cognito from '../libs/cognito';
+import { updateAxiosClient } from '../services';
 import { getAdminUserGroups } from '../services/user';
 
 export const AuthStatus = {
@@ -91,6 +92,8 @@ const AuthProvider = ({ children }) => {
       window.localStorage.setItem('accessToken', `${session.accessToken.jwtToken}`);
       window.localStorage.setItem('refreshToken', `${session.refreshToken.token}`);
 
+      updateAxiosClient(session.accessToken.jwtToken);
+
       const attr = await getAttributes();
       setAttrInfo(attr);
 
@@ -149,6 +152,9 @@ const AuthProvider = ({ children }) => {
     setAuthStatus(AuthStatus.SignedOut);
     setAdminGroups([]);
     setSessionInfo({});
+    window.localStorage.removeItem('accessToken');
+    window.localStorage.removeItem('refreshToken');
+    updateAxiosClient();
   }
 
   async function verifyCode(username, code) {

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -1,10 +1,20 @@
 import axios from 'axios';
 import config from '../../config';
 
-export const axiosClient = axios.create({
+export let axiosClient = axios.create({
   baseURL: config.BASE_URL,
   headers: {
     Authorization: `Bearer ${window.localStorage.getItem('accessToken')}`,
     Accpet: 'application/json',
   },
 });
+
+export const updateAxiosClient = (token) => {
+  axiosClient = axios.create({
+    baseURL: config.BASE_URL,
+    headers: {
+      Authorization: token ? `Bearer ${token}` : undefined,
+      Accpet: 'application/json',
+    },
+  });
+};


### PR DESCRIPTION
When you log out and log in with different account (e.g. admin), and then go to the pages, the API calls sometimes get 403/401. It was because the axiosClient was using the previous account's access token.  Because of this, when you log in with admin account, you sometimes saw no submissions showing (refresh fixes it).